### PR TITLE
Drop explicit call to DB facade that may not be available

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -110,7 +110,7 @@ class Model extends IlluminateModel
 
                     }else if($model->$attrname instanceof $classname){
                         $model->tmp_geo[$attrname] = $model->$attrname;
-                        $model->setAttribute( $attrname,  \DB::rawGeo( $model->$attrname ));
+                        $model->setAttribute( $attrname,  $this->getConnection()->rawGeo( $model->$attrname ));
 
                     }else{
                         throw new \Exception('Geometry attribute ' . $attrname .' must be an instance of ' . $classname);
@@ -166,7 +166,7 @@ class Model extends IlluminateModel
             # 3) WKT: else
             #
             if(!ctype_print($data) or ctype_xdigit($data)){
-                $wkb = \DB::fromRawToWKB(parent::__get($key));
+                $wkb = $this->getConnection()->fromRawToWKB(parent::__get($key));
                 $this->setAttribute($key, $classname::fromWKB($wkb));
 
             }else{ // assuming that it is in WKT


### PR DESCRIPTION
Hello!

Thanks for your work on this package!

This PR drops references to the DB facade.  I ran into an issue with this on a Lumen project that doesn't use Facades where there was a "Class 'DB' not found" exception thrown.  I noticed that the methods being called are actually on the Connection, so I opted to use the instance of the Connection that the model has access to anyway, rather than calling the DB facade.  :smile:

Thanks!